### PR TITLE
Close markdown code block in SHELL_MODULES.md

### DIFF
--- a/SHELL_MODULES.md
+++ b/SHELL_MODULES.md
@@ -52,6 +52,7 @@ outputs = inputs:
           ({self, ...}: {env.GREETINGS = self.lib.emphasize "Hello from a merged shell";}) # self.lib
           ({self', ...}: {inputsFrom = [self'.packages.default];}) # self'.packages
         ];
+```
 
 ## Basic Options
 


### PR DESCRIPTION
Missing code block end caused Github's markdown preview to break for SHELL_MODULES.md